### PR TITLE
"prop-types" dependency and new linter rules added

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,11 @@
 module.exports = {
   // extends: ['@mate-academy/eslint-config-react-typescript', 'plugin:cypress/recommended'],
   extends: ['@mate-academy/eslint-config-react', 'plugin:cypress/recommended'],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', {
+      devDependencies: false,
+      optionalDependencies: false,
+      peerDependencies: false,
+    }],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mate-academy/scripts": "^0.9.0",
     "@mate-academy/students-ts-config": "*",
     "@mate-academy/stylelint-config": "*",
+    "prop-types": "^15.7.2",
     "cypress": "^5.6.0",
     "eslint": "^7.32.0",
     "eslint-plugin-cypress": "^2.11.2",


### PR DESCRIPTION
There was a problem with compiling in react task ('prop-types' should be listed in the project's dependencies. Run 'npm i -S prop-types' to add it, installation of 'prop-types' didn't help)

In this PR was added linter rules that helped to fix this problem

Dependency "prop-types" was added to package.json too